### PR TITLE
Fix: use GMT time (as in the rest of the app) in date-time widget

### DIFF
--- a/src/app/booking/components/date-time-widget/date-time-widget.component.html
+++ b/src/app/booking/components/date-time-widget/date-time-widget.component.html
@@ -1,8 +1,8 @@
 <div class="date-time" [ngClass]="{ departure: isDeparture, arrival: !isDeparture }">
-  <span class="date">{{ date | date : getFormatForDatePipe(dateFormat) }}</span>
+  <span class="date">{{ date | date : getFormatForDatePipe(dateFormat) : 'Z' }}</span>
   <div class="time-timezone">
-    <span class="time">{{ date | date : 'H:mm' }}</span>
-    <span class="timezone">{{ date | date : 'zzz' }}</span>
+    <span class="time">{{ date | date : 'H:mm' : 'Z' }}</span>
+    <span class="timezone">{{ date | date : 'zzz' : 'Z' }}</span>
   </div>
   <span class="airport-name">{{ airportName }}</span>
 </div>


### PR DESCRIPTION
## Fix: use GMT time (as in the rest of the app) in date-time widget

- Fix: time display was inconsistent. One of the `booking-flights` widgets displayed time in the local timezone, while the rest of the app uses GMT time.