### PR TITLE
Fix: hide flight-details component if there are no seats

### DIFF
--- a/src/app/booking/components/flight-details/flight-details.component.html
+++ b/src/app/booking/components/flight-details/flight-details.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="flight">
+<ng-container *ngIf="flight && flight.availableSeats > 0">
   <div class="flight-details" [ngClass]="{ selected: isFlightSelected }">
     <div class="flight-details-left">
       <air-date-time-widget


### PR DESCRIPTION
## Fix: hide flight-details component if there are no seats

- Now the component which allows user to select flight on `booking-flights` page is hidden if the flight has no available seats.